### PR TITLE
feat: implement remember me functionality for authentication

### DIFF
--- a/src/models/refresh-token.js
+++ b/src/models/refresh-token.js
@@ -16,6 +16,10 @@ const refreshTokenSchema = new mongoose.Schema(
       type: String,
       maxlength: [24, 'Should have less than 25 characters'],
       required: [true, 'Is required']
+    },
+    rememberMe: {
+      type: Boolean,
+      default: false
     }
   },
   { timestamps: true }

--- a/src/routes/auth/facebook-sign-in.js
+++ b/src/routes/auth/facebook-sign-in.js
@@ -16,6 +16,7 @@ module.exports = async (req, res, next) => {
   // }
 
   let token = req?.body?.code;
+  const rememberMe = req.body.rememberMe || false;
   try {
     if (req.body.web) {
       const tokenResponse = await axios.get(
@@ -75,18 +76,23 @@ module.exports = async (req, res, next) => {
         await User.findByIdAndUpdate(user._id, { lastLogin: new Date() });
       }
 
+      // Set token expiration based on rememberMe
+      // If rememberMe is true: 90 days, otherwise: 7 days
+      const tokenExpirationDays = rememberMe ? 90 : 7;
+      const jwtExpiration = rememberMe ? '90d' : '7d';
+
       const userId = user._id;
       const today = moment.utc();
-      const expiresAt = today.add(30, "days").toDate();
+      const expiresAt = today.add(tokenExpirationDays, "days").toDate();
       const key = `${userId}${crypto.randomBytes(28).toString("hex")}`;
 
       let refreshToken = await RefreshToken.findOneAndUpdate(
         { userId },
-        { expiresAt, key, userId },
+        { expiresAt, key, userId, rememberMe },
         { new: true, setDefaultsOnInsert: true, upsert: true }
       );
       const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
-        expiresIn: "30d",
+        expiresIn: jwtExpiration,
       });
 
       res.json({

--- a/src/routes/auth/generate-token.js
+++ b/src/routes/auth/generate-token.js
@@ -44,11 +44,15 @@ module.exports = async (req, res, next) => {
     return res.status(401).json({ general: "Refresh Token expired" });
   }
 
+  // Generate JWT with expiration based on rememberMe flag
+  // If rememberMe is true: 90 days, otherwise: 7 days
+  const jwtExpiration = refreshToken.rememberMe ? '90d' : '7d';
+
   const token = jwt.sign(
     { userId: refreshToken.userId },
     process.env.JWT_SECRET,
     {
-      expiresIn: '30d',
+      expiresIn: jwtExpiration,
     }
   );
   return res.status(200).json({ token });

--- a/src/routes/auth/google-sign-in.js
+++ b/src/routes/auth/google-sign-in.js
@@ -22,6 +22,7 @@ module.exports = async (req, res) => {
   }
 
   let code = req.body.code;
+  const rememberMe = req.body.rememberMe || false;
   const oauth2Client = new OAuth2Client(CLIENT_ID);
   try {
     const deviceType = req.headers["x-device-type"];
@@ -76,18 +77,23 @@ module.exports = async (req, res) => {
       await User.findByIdAndUpdate(user._id, { lastLogin: new Date() });
     }
 
+    // Set token expiration based on rememberMe
+    // If rememberMe is true: 90 days, otherwise: 7 days
+    const tokenExpirationDays = rememberMe ? 90 : 7;
+    const jwtExpiration = rememberMe ? '90d' : '7d';
+
     const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
-      expiresIn: "30d",
+      expiresIn: jwtExpiration,
     });
 
     const userId = user._id;
     const today = moment.utc();
-    const expiresAt = today.add(30, "days").toDate();
+    const expiresAt = today.add(tokenExpirationDays, "days").toDate();
     const key = `${userId}${crypto.randomBytes(28).toString("hex")}`;
 
     let refreshToken = await RefreshToken.findOneAndUpdate(
       { userId },
-      { expiresAt, key, userId },
+      { expiresAt, key, userId, rememberMe },
       { new: true, setDefaultsOnInsert: true, upsert: true }
     );
 

--- a/src/routes/auth/sign-in.js
+++ b/src/routes/auth/sign-in.js
@@ -16,6 +16,7 @@ module.exports = async (req, res, next) => {
 
   const email = req.body.email;
   const password = req.body.password;
+  const rememberMe = req.body.rememberMe || false;
 
   let user;
   try {
@@ -54,15 +55,20 @@ module.exports = async (req, res, next) => {
     // Continue with login even if lastLogin update fails
   }
 
+  // Set token expiration based on rememberMe
+  // If rememberMe is true: 90 days, otherwise: 7 days (short-lived session)
+  const tokenExpirationDays = rememberMe ? 90 : 7;
+  const jwtExpiration = rememberMe ? '90d' : '7d';
+
   const today = moment.utc();
-  const expiresAt = today.add(30, "days").toDate();
+  const expiresAt = today.add(tokenExpirationDays, "days").toDate();
   const key = `${userId}${crypto.randomBytes(28).toString("hex")}`;
 
   let refreshToken;
   try {
     refreshToken = await RefreshToken.findOneAndUpdate(
       { userId },
-      { expiresAt, key, userId },
+      { expiresAt, key, userId, rememberMe },
       { new: true, setDefaultsOnInsert: true, upsert: true }
     );
   } catch (err) {
@@ -73,7 +79,7 @@ module.exports = async (req, res, next) => {
   }
 console.log(process.env.JWT_SECRET)
   const token = jwt.sign({ userId }, process.env.JWT_SECRET, {
-    expiresIn: '30d',
+    expiresIn: jwtExpiration,
   });
   return res.status(200).json({ refreshToken: refreshToken.key, token });
 };

--- a/src/routes/auth/validations.js
+++ b/src/routes/auth/validations.js
@@ -16,6 +16,10 @@ module.exports = {
       errors.code = "Should be a string";
     }
 
+    if (data.rememberMe !== undefined && typeof data.rememberMe !== "boolean") {
+      errors.rememberMe = "Should be a boolean";
+    }
+
     return { errors, isValid: isEmpty(errors) };
   },
   validateAppleSignIn(data) {
@@ -62,6 +66,10 @@ module.exports = {
       errors.code = "Should be a string";
     }
 
+    if (data.rememberMe !== undefined && typeof data.rememberMe !== "boolean") {
+      errors.rememberMe = "Should be a boolean";
+    }
+
     return { errors, isValid: isEmpty(errors) };
   },
   validateResetPassword(data) {
@@ -98,6 +106,10 @@ module.exports = {
       errors.password = "Is required";
     } else if (typeof data.password !== "string") {
       errors.password = "Should be a string";
+    }
+
+    if (data.rememberMe !== undefined && typeof data.rememberMe !== "boolean") {
+      errors.rememberMe = "Should be a boolean";
     }
 
     return { errors, isValid: isEmpty(errors) };


### PR DESCRIPTION
- Add rememberMe field to RefreshToken model (defaults to false)
- Update sign-in validation to accept optional rememberMe parameter
- Implement dual token expiration:
  * Without remember me: 7 days
  * With remember me: 90 days
- Apply to all auth methods: email, Google OAuth, Facebook OAuth
- Token refresh respects original rememberMe preference